### PR TITLE
Changed fabric.mod.json.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,5 +29,8 @@
     "minecraft": "1.16.x",
     "fabricloader": ">=0.9.0",
     "carpet": "*"
+  },
+  "custom": {
+    "modmenu:parent": "carpet"
   }
 }


### PR DESCRIPTION
Changed fabric.mod.json to make it so that XpBeacons displays as a sub-part of carpet in modmenu, as Carpet TIS Additions has already done.